### PR TITLE
Tcpdump command did not create the PTAT folder needed for the dump fi…

### DIFF
--- a/app/src/main/java/com/imdea/fioravantti/guido/ecousin_ptat/model/TCPDumpAPI.java
+++ b/app/src/main/java/com/imdea/fioravantti/guido/ecousin_ptat/model/TCPDumpAPI.java
@@ -66,6 +66,7 @@ public class TCPDumpAPI {
 
             DataOutputStream dos = new DataOutputStream(su.getOutputStream());
 
+            ensureDirectory();
             enterCommand(command, dos);
 
             dos.close();


### PR DESCRIPTION
…le. ensureDirectory() is now used to avoid that.
